### PR TITLE
Fixed "Cannot read property 'length' of undefined" responses from the bot

### DIFF
--- a/BotRunner.js
+++ b/BotRunner.js
@@ -1,3 +1,4 @@
+const { WIKIDATA_ERROR } = require('./constants');
 const DeadOrAlive = require('./DeadOrAlive');
 
 const parseTextFromCommand = (text, commandOffset) => {
@@ -25,6 +26,10 @@ const buildResponse = searchTerm => new Promise(async (resolve) => {
     } catch (e) {
         if (e.message === 'not-found') {
             return resolve(`Couldn't find a person named ${searchTerm}.`);
+        }
+
+        if (e.message === WIKIDATA_ERROR) {
+            return resolve(`Oops! The bot seems to be having issues - please open an issue at https://github.com/weiran/dead-or-alive-bot/issues (include your search term) and I'll take a look 👀😁`);
         }
 
         return resolve(e.message);

--- a/DeadOrAlive.js
+++ b/DeadOrAlive.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 const wiki = require('wikidata-sdk');
 
 const overrides = require('./Overrides');
+const { WIKIDATA_ERROR } = require('./constants');
 
 const WikiDataDateFormat = "'+'YYYY-MM-DD'T'hh:mm:ss'Z'";
 const DefaultDateFormat = 'MMMM Do YYYY';
@@ -29,8 +30,14 @@ const getEntityIds = async (searchTerm) => {
         search: searchTerm,
         format: 'json',
     });
+
     const searchResult = await axios.get(url);
-    if (searchResult.data.search.length === 0) {
+
+    if (searchResult.data.error) {
+        throw new Error(WIKIDATA_ERROR);
+    }
+
+    if (!searchResult.data.search || searchResult.data.search.length === 0) {
         throw new Error('not-found');
     }
     return searchResult.data.search.map(entity => entity.id).slice(0, 5);

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,5 @@
+const WIKIDATA_ERROR = 'internal error';
+
+module.exports = {
+  WIKIDATA_ERROR,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,10 +2137,18 @@
         "string-width": "^1.0.2 || 2"
       }
     },
+    "wikibase-sdk": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.2.1.tgz",
+      "integrity": "sha512-aK9NWsekwoNk7wJn5lAK8dDzDkZcUMCM6Bmtc+r/sNhaOFBLT43GJEgHKW0mvko/3uKfDtkHkDtrq9pa9/egrw=="
+    },
     "wikidata-sdk": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-6.7.0.tgz",
-      "integrity": "sha512-X4Fuv7kd1Gfy+x0O8uM3J+Q0hnxS9RRrkLy76/btN049abroSrD1Mi/WC3vvYrUchqQWwKgF9EdYhNUOBU/Mpw=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.2.0.tgz",
+      "integrity": "sha512-BBLGla+3p7U4aGOPjKkurDEPkNPHQM8JsaNMIu+ERGcKFSxmVyUy6UKSpkNWHzU3+no1elXStZkx57o/Sq7u3A==",
+      "requires": {
+        "wikibase-sdk": "^7.2.0"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "moment": "^2.24.0",
     "qs": "^6.7.0",
     "telegraf": "^3.29.0",
-    "wikidata-sdk": "^6.7.0"
+    "wikidata-sdk": "^7.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
There was a breaking change to the wikidata api in February 2020 -
https://lists.wikimedia.org/pipermail/mediawiki-api-announce/2020-February/000152.html

This caused the params added to our request by the wikidata sdk to fail validation on the server; and we received back a 'badinteger' error.

We didn't handle the error at all, so when we didn't nullcheck `searchResult.data.search`, the "Cannot read property 'length' of undefined" got delivered to the user.

### The new friendly error message
<img src="https://user-images.githubusercontent.com/21317379/74604754-bf2fb200-50b8-11ea-996b-09626e491ec2.png" width="300px" />

### Changes
- Bumped `wikidata-sdk` to latest
- Handle known errors from the wikidata api with friendly message to user